### PR TITLE
Excluding Test files from sonarscanner scans

### DIFF
--- a/scripts/reports/perform-static-analysis.sh
+++ b/scripts/reports/perform-static-analysis.sh
@@ -35,7 +35,11 @@ function create-report() {
     sonarsource/sonar-scanner-cli:$image_version \
       -Dproject.settings=/usr/src/scripts/config/sonar-scanner.properties \
       -Dsonar.branch.name="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}" \
-      -Dsonar.token="$(echo $SONAR_TOKEN)"
+      -Dsonar.organization="$(echo $SONAR_ORGANISATION_KEY)" \
+      -Dsonar.projectKey="$(echo $SONAR_PROJECT_KEY)" \
+      -Dsonar.token="$(echo $SONAR_TOKEN)" \
+      -Dsonar.javascript.lcov.reportPaths="coverage/lcov.info" \
+      -Dsonar.coverage.exclusions="**/*test.js,**/*spec.js"
 }
 
 function is_arg_true() {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Modified the `scripts/reports/perform-static-analysis.sh` script to exclude the test files for the Soncarcloud scans. 

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
