### PR TITLE
memory increase for caas validate lambda

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1253,7 +1253,7 @@ module "validate_caas_feed_lambda" {
   lambda_iam_role      = module.iam_galleri_lambda_role.galleri_lambda_role_arn
   lambda_function_name = "validateCaasFeedLambda"
   lambda_timeout       = 100
-  memory_size          = 1024
+  memory_size          = 4096
   lambda_s3_object_key = "validate_caas_feed_lambda.zip"
   environment_vars = {
     ENVIRONMENT = "${var.environment}"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
https://nhsd-jira.digital.nhs.uk/browse/GAL-1230

<!-- Describe your changes in detail. -->
memory for validateCaasFeedLambda increased to 4GB (4096 MB) in main.tf.
Tested it in dev-5. Memory is increased on env startup for validateCaasFeedLambda.
Also processing files with 2.5 million records without any error with this size.
## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
