### PR TITLE
shortened backup names as seeing some failures due to lenght

### DIFF
--- a/terraform/modules/dynamodb/dynamodb.tf
+++ b/terraform/modules/dynamodb/dynamodb.tf
@@ -42,11 +42,11 @@ resource "aws_dynamodb_table" "dynamodb_table" {
 }
 
 resource "aws_backup_vault" "dynamodb_vault" {
-  name = "${var.environment}-${var.table_name}-dynamodb-backup-vault"
+  name = "${var.environment}-${var.table_name}"
 }
 
 resource "aws_backup_plan" "dynamodb_backup_plan" {
-  name = "${var.environment}-${var.table_name}-dynamodb-backup-plan"
+  name = "${var.environment}-${var.table_name}"
 
   rule {
     rule_name         = "daily-backup"
@@ -62,7 +62,7 @@ resource "aws_backup_plan" "dynamodb_backup_plan" {
 }
 
 resource "aws_backup_selection" "dynamodb_backup_selection" {
-  name         = "${var.environment}-${var.table_name}-dynamodb-backup-selection"
+  name         = "${var.environment}-${var.table_name}"
   iam_role_arn = aws_iam_role.backup_role.arn
   plan_id      = aws_backup_plan.dynamodb_backup_plan.id
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
I have reduced the length of the names in the dynamodb module
<!-- Describe your changes in detail. -->

## Context
I saw some failures in the dev repos becuase of the names being too long
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
