### PR TITLE
removed dependabot from cicd pipeline

### DIFF
--- a/.github/workflows/cicd-0-commit.yaml
+++ b/.github/workflows/cicd-0-commit.yaml
@@ -7,7 +7,6 @@ on:
     branches:
       - "feature/**"
       - "hotfix/**"
-      - "dependabot/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
We dont need to check the commits for dependabot
<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->
Dependabot goes through the nft pipeline and as we are not developing on those branches there is no need to run it in two pipelines at the same time
## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
