### PR TITLE
Added sort key to episode history table

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2187,6 +2187,7 @@ module "episode_history_table" {
   stream_view_type = "NEW_AND_OLD_IMAGES"
   table_name       = "EpisodeHistory"
   hash_key         = "Participant_Id"
+  range_key        = "Episode_Event_Updated"
   read_capacity    = 10
   write_capacity   = 10
   environment      = var.environment
@@ -2194,6 +2195,10 @@ module "episode_history_table" {
   attributes = [
     {
       name = "Participant_Id"
+      type = "S"
+    },
+    {
+      name = "Episode_Event_Updated"
       type = "S"
     }
   ]

--- a/terraform/src/addEpisodeHistoryLambda/addEpisodeHistoryLambda.js
+++ b/terraform/src/addEpisodeHistoryLambda/addEpisodeHistoryLambda.js
@@ -69,10 +69,12 @@ export const formatEpisodeHistoryRecord = (record) => {
       Participant_Id: {
         S: `${record.Participant_Id.S}`,
       },
+      Episode_Event_Updated: {
+        S: `${record?.Episode_Event_Updated.S}`
+      },
     },
     ExpressionAttributeNames: {
       "#EE": "Episode_Event",
-      "#EEU": "Episode_Event_Updated",
       "#EED": "Episode_Event_Description",
       "#EEN": "Episode_Event_Notes",
       "#EEUB": "Episode_Event_Updated_By",
@@ -82,9 +84,6 @@ export const formatEpisodeHistoryRecord = (record) => {
     ExpressionAttributeValues: {
       ":episode_event": {
         S: `${record?.Episode_Event.S}`,
-      },
-      ":episode_event_updated": {
-        S: `${record?.Episode_Event_Updated.S}`,
       },
       ":episode_event_description": {
         S:
@@ -112,7 +111,7 @@ export const formatEpisodeHistoryRecord = (record) => {
       },
     },
     TableName: `${ENVIRONMENT}-EpisodeHistory`,
-    UpdateExpression: `set #EE = :episode_event, #EEU = :episode_event_updated, #EED = :episode_event_description, #EEN = :episode_event_notes, #EEUB = :episode_event_updated_by, #ES = :episode_status, #ESU = :episode_status_updated`,
+    UpdateExpression: `set #EE = :episode_event, #EED = :episode_event_description, #EEN = :episode_event_notes, #EEUB = :episode_event_updated_by, #ES = :episode_status, #ESU = :episode_status_updated`,
   };
 
   return params;

--- a/terraform/src/tests/unitTests/addEpisodeHistoryLambda.test.js
+++ b/terraform/src/tests/unitTests/addEpisodeHistoryLambda.test.js
@@ -39,10 +39,12 @@ describe("formatEpisodeHistoryRecord", () => {
         Participant_Id: {
           S: `ID_1`,
         },
+        Episode_Event_Updated: {
+          S: `20`,
+        },
       },
       ExpressionAttributeNames: {
         "#EE": "Episode_Event",
-        "#EEU": "Episode_Event_Updated",
         "#EED": "Episode_Event_Description",
         "#EEN": "Episode_Event_Notes",
         "#EEUB": "Episode_Event_Updated_By",
@@ -52,9 +54,6 @@ describe("formatEpisodeHistoryRecord", () => {
       ExpressionAttributeValues: {
         ":episode_event": {
           S: `Episode_Event_1`,
-        },
-        ":episode_event_updated": {
-          S: `20`,
         },
         ":episode_event_description": {
           S: `Episode_Event_Description_1`,
@@ -73,7 +72,7 @@ describe("formatEpisodeHistoryRecord", () => {
         },
       },
       TableName: `undefined-EpisodeHistory`,
-      UpdateExpression: `set #EE = :episode_event, #EEU = :episode_event_updated, #EED = :episode_event_description, #EEN = :episode_event_notes, #EEUB = :episode_event_updated_by, #ES = :episode_status, #ESU = :episode_status_updated`,
+      UpdateExpression: `set #EE = :episode_event, #EED = :episode_event_description, #EEN = :episode_event_notes, #EEUB = :episode_event_updated_by, #ES = :episode_status, #ESU = :episode_status_updated`,
     };
 
     const mockRecord = {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Added episode_event_update field as sort key in episode history table so that an episode history record is not overwritten when the episode_event_update field updated in the episode table. 

This is required because episode history table should store all updates to episode table, whereas episode table is the latest event and status of a participant.

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
