### PR TITLE
Feature/disable backups except prod

### DIFF
--- a/terraform/modules/dynamodb/dynamodb.tf
+++ b/terraform/modules/dynamodb/dynamodb.tf
@@ -47,21 +47,21 @@ resource "aws_dynamodb_table" "dynamodb_table" {
 }
 
 resource "aws_backup_vault" "dynamodb_vault" {
-  count = var.environment == "prod" ? 1 : 0
-  name = "${var.environment[count.index]}-${var.table_name}"
+  count = contains(var.envs_to_backup, var.environment) ? 1 : 0
+  name  = "${var.environment}-${var.table_name}"
   tags = {
     ApplicationRole = "${var.application_role}"
-    Name            = "${var.environment.count.index} DynamoDB Vault"
+    Name            = "${var.environment} DynamoDB Vault"
   }
 }
 
 resource "aws_backup_plan" "dynamodb_backup_plan" {
-  count = var.environment == "prod" ? 1 : 0
-  name = "${var.environment}-${var.table_name}"
+  count = contains(var.envs_to_backup, var.environment) ? 1 : 0
+  name  = "${var.environment}-${var.table_name}"
 
   rule {
     rule_name         = "daily-backup"
-    target_vault_name = aws_backup_vault.dynamodb_vault[*].name
+    target_vault_name = aws_backup_vault.dynamodb_vault[0].name
     schedule          = var.schedule
     start_window      = 120
     completion_window = 360
@@ -77,10 +77,10 @@ resource "aws_backup_plan" "dynamodb_backup_plan" {
 }
 
 resource "aws_backup_selection" "dynamodb_backup_selection" {
-  count = var.environment == "prod" ? 1 : 0
+  count        = contains(var.envs_to_backup, var.environment) ? 1 : 0
   name         = "${var.environment}-${var.table_name}"
   iam_role_arn = aws_iam_role.backup_role.arn
-  plan_id      = aws_backup_plan.dynamodb_backup_plan[*].id
+  plan_id      = aws_backup_plan.dynamodb_backup_plan[0].id
 
   resources = [aws_dynamodb_table.dynamodb_table.arn]
 }

--- a/terraform/modules/dynamodb/variables.tf
+++ b/terraform/modules/dynamodb/variables.tf
@@ -82,7 +82,7 @@ variable "environment" {}
 variable "envs_to_backup" {
   description = "A list of environments to select for backing up dynamodb tables"
   type        = list(string)
-  default     = [ "prod" ]
+  default     = ["prod"]
 }
 
 variable "stream_enabled" {

--- a/terraform/modules/dynamodb/variables.tf
+++ b/terraform/modules/dynamodb/variables.tf
@@ -79,6 +79,12 @@ variable "tags" {
 
 variable "environment" {}
 
+variable "envs_to_backup" {
+  description = "A list of environments to select for backing up dynamodb tables"
+  type        = list(string)
+  default     = [ "prod" ]
+}
+
 variable "stream_enabled" {
   default = false
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
This change disables dynamodb backups and backup plans on all environments except for "prod", though allows extending the selected environments in future.
<!-- Describe your changes in detail. -->

## Context
It's been decided that it's safer to not enable backup deletion permissions for users, which can lead to pipeline builds getting stuck on dev & test if backup recovery points had been lingering.
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
